### PR TITLE
If getting a NE component container by name doesn't work, try by service name and project name.

### DIFF
--- a/code/agent/common/util.py
+++ b/code/agent/common/util.py
@@ -16,7 +16,10 @@ from subprocess import (Popen, run, PIPE, TimeoutExpired,
 base_label = 'nuvlaedge.component=True'
 default_project_name = 'nuvlaedge'
 compose_project_name = os.getenv('COMPOSE_PROJECT_NAME', default_project_name)
-compute_api = compose_project_name + '-compute-api'
+compute_api_service_name = 'compute-api'
+compute_api = compose_project_name + '-' + compute_api_service_name
+job_engine_service_name = 'job-engine-lite'
+vpn_client_service_name = 'vpn-client'
 
 COMPUTE_API_INTERNAL_PORT = 5000
 

--- a/code/agent/orchestrator/__init__.py
+++ b/code/agent/orchestrator/__init__.py
@@ -23,9 +23,9 @@ class ContainerRuntimeClient(ABC):
 
     def __init__(self):
         self.client = None
-        self.job_engine_lite_component = util.compose_project_name + "-job-engine-lite"
+        self.job_engine_lite_component = util.compose_project_name + "-" + util.job_engine_service_name
         self.job_engine_lite_image = None
-        self.vpn_client_component = util.compose_project_name + '-vpn-client'
+        self.vpn_client_component = util.compose_project_name + '-' + util.vpn_client_service_name
         self.ignore_env_variables = ['NUVLAEDGE_API_KEY', 'NUVLAEDGE_API_SECRET']
         self.data_gateway_name = None
 


### PR DESCRIPTION
And do not fail if compute-api is not found.

Sometime Docker Compose prefix the container name with container id (for example if the previous one hasn't been removed yet).